### PR TITLE
Add print statement for testing CI/CD pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # ST-A3
 
 # Roll No: 21L-5152
+Testing CI/CD pipeline

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "st-a3",
+  "version": "1.0.0",
+  "description": "\"CI?/CD Pipeline Project\"",
+  "main": "index.js",
+  "scripts": {
+    "test": "\"echo \\\"Error: no test specified\\\" && exit 1\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ifrajavaid14/ST-A3.git"
+  },
+  "keywords": [
+    "\"CI/CD\"",
+    "\"GitHub\"",
+    "\"Workflow\"",
+    "\"Pipeline\"",
+    "\"Integration\"",
+    "\"Deployment\""
+  ],
+  "author": "\"Ifra Javeed\"",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ifrajavaid14/ST-A3/issues"
+  },
+  "homepage": "https://github.com/ifrajavaid14/ST-A3#readme",
+  "dependencies": {
+    "express": "^4.21.1"
+  }
+}

--- a/some_file.py
+++ b/some_file.py
@@ -1,0 +1,1 @@
+print('Testing CI pipeline')

--- a/some_file.py
+++ b/some_file.py
@@ -1,1 +1,2 @@
 print('Testing CI pipeline')
+print('Testing CI pipeline')


### PR DESCRIPTION
In this pull request, I have added a print statement to some_file.py for testing the CI/CD pipeline. This change is intended to verify that the GitHub Actions workflow correctly identifies and runs the unit tests as part of the continuous integration process.